### PR TITLE
Quick fix for error being thrown when using SelectFrom with a string $where

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -250,6 +250,10 @@ class ExtendedPdo extends AuraPdo implements ExtendedPdoInterface
 	public function selectFrom($table, $where, $type='one', $fields = "*"){
 		$query = self::selectFromQuery($table, $where, $fields);
 		$func = 'fetch'.ucfirst($type);
+		//if we had a string $where, pass on an empty array as where
+		if (!is_array($where)){
+			$where = [];
+		}
 		$data = $this->$func($query, $where);
 		return $data;
 	}


### PR DESCRIPTION
Adjusted selectFrom method so it doesn't pass on a string $where to a fetch... function that expects an array $where.

Have not added a test.
