### PR TITLE
Allow selectField to return null

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -28,7 +28,11 @@ class ExtendedPdo extends AuraPdo{
      * @param string $server
      */
 	public function __construct(string $db, string $user, string $pass, array $options = [], string $charset = 'utf8', string $type = 'mysql', string $server = 'localhost'){
-		$dsn = "$type:host={$server};dbname={$db}";
+		if ($type==='sqlite' && $server==='memory') {
+			$dsn = "sqlite::memory:";
+		} else {
+			$dsn = "$type:host={$server};dbname={$db}";
+		}
 
 		if (!empty($charset)){
 			$dsn .= ";charset={$charset}";
@@ -583,9 +587,9 @@ class ExtendedPdo extends AuraPdo{
 	 * @param string $table
 	 * @param string|array<string, scalar> $where
 	 * @param array|string $field
-	 * @return string
+	 * @return ?string
 	 */
-	public function selectField(string $table, $where, $field):string{
+	public function selectField(string $table, $where, $field):?string{
 		return $this->selectFrom($table, $where, 'field', $field);
 	}
 

--- a/tests/TestExtendedPdo.php
+++ b/tests/TestExtendedPdo.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use M1ke\Sql\Exception as ExtendedPdoException;
 use M1ke\Sql\ExtendedPdo;
@@ -291,5 +291,26 @@ class TestExtendedPdo extends TestCase {
 		$val = ExtendedPdo::fetchFieldReturn([]);
 
 		self::assertSame('', $val);
+	}
+
+	public function testSelectField(){
+		$pdo = new ExtendedPdo('', '', '', [], '', 'sqlite', 'memory');
+		$pdo->exec('create table testTable (testId INTEGER, name varchar, nullable varchar)');
+		$pdo->exec('insert into testTable values (1, \'a\', null)');
+		$result = $pdo->selectField('testTable', [
+			'name' => 'a',
+		], 'testId');
+
+		self::assertSame('1', $result);
+		$result = $pdo->selectField('testTable', [
+			'name' => 'b',
+		], 'testId');
+
+		self::assertSame('', $result);
+		$result = $pdo->selectField('testTable', [
+			'name' => 'a',
+		], 'nullable');
+
+		self::assertNull($result);
 	}
 }


### PR DESCRIPTION
Allow selectField to return null, which can occur if the field has null as a value, but not if the row does not exist